### PR TITLE
Basic trait support

### DIFF
--- a/src/Archetype.zig
+++ b/src/Archetype.zig
@@ -35,6 +35,7 @@ pub fn fromComponentSet(
             meta.id,
             meta.size,
             meta.alignment,
+            meta.trait,
         );
     }
 

--- a/src/ComponentArray.zig
+++ b/src/ComponentArray.zig
@@ -33,8 +33,9 @@ pub fn initFromType(
     id: ComponentId,
     size: usize,
     alignment: u29,
+    trait: ?ComponentId,
 ) ComponentArray {
-    const meta = ComponentMeta.init(id, size, alignment);
+    const meta = ComponentMeta.init(id, size, alignment, trait);
     return ComponentArray.init(allocator, meta);
 }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -28,24 +28,39 @@ pub const ComponentMeta = struct {
     size: usize,
     alignment: u29,
     stride: usize,
+    trait: ?ComponentId,
 
-    pub fn init(id: ComponentId, size: usize, alignment: u29) ComponentMeta {
+    pub fn init(id: ComponentId, size: usize, alignment: u29, trait: ?ComponentId) ComponentMeta {
         const stride = if (size == 0) 0 else std.mem.alignForward(usize, size, alignment);
         return ComponentMeta{
             .id = id,
             .size = size,
             .alignment = alignment,
             .stride = stride,
+            .trait = trait,
         };
     }
 
     pub fn from(comptime T: anytype) ComponentMeta {
         // This can be used with a type or a value.
         const ComponentT = if (@TypeOf(T) == type) T else @TypeOf(T);
+
+        // check for the __trait__ declaration
+        if (@hasDecl(ComponentT, "__trait__")) {
+            const trait_id = componentId(ComponentT.__trait__);
+            return ComponentMeta.init(
+                componentId(ComponentT),
+                @sizeOf(ComponentT),
+                @alignOf(ComponentT),
+                trait_id,
+            );
+        }
+
         return ComponentMeta.init(
             componentId(ComponentT),
             @sizeOf(ComponentT),
             @alignOf(ComponentT),
+            null,
         );
     }
 

--- a/src/tests/fixtures.zig
+++ b/src/tests/fixtures.zig
@@ -65,6 +65,7 @@ pub fn createPositionArray(allocator: std.mem.Allocator) ComponentArray {
         componentId(Position),
         @sizeOf(Position),
         @alignOf(Position),
+        null,
     );
 }
 
@@ -75,6 +76,7 @@ pub fn createHealthArray(allocator: std.mem.Allocator) ComponentArray {
         componentId(Health),
         @sizeOf(Health),
         @alignOf(Health),
+        null,
     );
 }
 
@@ -85,6 +87,7 @@ pub fn createMarkerArray(allocator: std.mem.Allocator) ComponentArray {
         componentId(Marker),
         @sizeOf(Marker),
         @alignOf(Marker),
+        null,
     );
 }
 
@@ -95,6 +98,7 @@ pub fn createPopulatedArray(allocator: std.mem.Allocator, comptime T: type, item
         componentId(T),
         @sizeOf(T),
         @alignOf(T),
+        null,
     );
 
     for (items) |item| {

--- a/src/tests/test_components.zig
+++ b/src/tests/test_components.zig
@@ -56,6 +56,18 @@ test "componentId generates the same ID from a value and its type" {
     try testing.expectEqual(pos_id, pos_type_id);
 }
 
+test "ComponentMeta from detects traits" {
+    const Superclass = struct {
+        id: u64,
+    };
+    const Subclass = struct {
+        id: u64,
+        pub const __trait__ = Superclass;
+    };
+    const meta = root.ComponentMeta.from(Subclass);
+    try testing.expectEqual(componentId(Superclass), meta.trait);
+}
+
 test "ComponentArray initialization and deinitialization" {
     const allocator = testing.allocator;
 
@@ -350,6 +362,7 @@ test "ComponentArray large component handling" {
         componentId(LargeComponent),
         @sizeOf(LargeComponent),
         @alignOf(LargeComponent),
+        null,
     );
     defer large_array.deinit();
 


### PR DESCRIPTION
This will allow the implementation of `Renderable` and `Layer2d(N)` in `phasor` (the parent project). It's limited to one trait for now, but this could be easily expanded. The general idea is that you can do this:

```zig
fn Component(N: i32) type {
    return struct {
        n: i32 = N,
        pub const __trait__ = ComponentX;
    };
}

const ComponentX = struct{
    n: i32,
};
```

The query for `ComponentX` will now match `Component(1)`, `Component(2)`, etc.