### PR TITLE
`Transaction`

### DIFF
--- a/src/Transaction.zig
+++ b/src/Transaction.zig
@@ -2,16 +2,20 @@ const std = @import("std");
 const root = @import("root.zig");
 const Database = root.Database;
 const Entity = root.Entity;
+const Query = root.Query;
+const ComponentId = root.ComponentId;
 
 allocator: std.mem.Allocator,
 database: *Database,
 commands: std.ArrayListUnmanaged(Command) = .empty,
+has_executed: bool = false,
 
 const Transaction = @This();
 
 const Command = struct {
-    context: *anyopaque,
+    context: *anyopaque, // TODO: not sure this is the simplest way. the problem is that we need to capture the comptime components specs
     execute: *const fn (ctx: *anyopaque, db: *Database) anyerror!void,
+    cleanup: *const fn (ctx: *anyopaque, allocator: std.mem.Allocator) void,
 };
 
 pub fn init(allocator: std.mem.Allocator, database: *Database) Transaction {
@@ -22,28 +26,173 @@ pub fn init(allocator: std.mem.Allocator, database: *Database) Transaction {
 }
 
 pub fn deinit(self: *Transaction) void {
+    // Clean up any remaining command contexts
+    for (self.commands.items) |command| {
+        command.cleanup(command.context, self.allocator);
+    }
     self.commands.deinit(self.allocator);
 }
 
 pub fn execute(self: *Transaction) !void {
+    if (self.has_executed) {
+        return error.TransactionAlreadyExecuted;
+    }
     for (self.commands.items) |command| {
         try command.execute(command.context, self.database);
+        // Clean up the allocated context after execution
+        command.cleanup(command.context, self.allocator);
     }
-    self.commands.clear();
+    self.commands.clearRetainingCapacity();
+    self.has_executed = true;
 }
 
+//
+// Facade commands: passthrough to db immediately
+//
+
+pub fn getEntity(self: *Transaction, entity_id: Entity.Id) ?Entity {
+    return self.database.getEntity(entity_id);
+}
+
+pub fn query(self: *Transaction, components: anytype) !Query {
+    return self.database.query(components);
+}
+
+pub fn groupBy(self: *Transaction, component_id: ComponentId, key: i32) !*const root.Group {
+    return self.database.groupBy(component_id, key);
+}
+
+//
+// Deferred commands: queued to be executed later
+//
+
 pub fn createEntity(self: *Transaction, components: anytype) !Entity.Id {
-    // ...
+    // We will make explicit use of Database.reserveEntityId and Database.createEntityWithId
+    // so that the caller still gets an Entity.Id, but the command can be deferred.
+    const entity_id = self.database.reserveEntityId();
+    
+    // Create a context that captures the entity_id and components for deferred execution
+    const CreateEntityContext = struct {
+        entity_id: Entity.Id,
+        components: @TypeOf(components),
+        
+        fn execute(ctx: *anyopaque, db: *Database) anyerror!void {
+            const self_ctx = @as(*@This(), @ptrCast(@alignCast(ctx)));
+            _ = try db.createEntityWithId(self_ctx.entity_id, self_ctx.components);
+        }
+        
+        fn cleanup(ctx: *anyopaque, allocator: std.mem.Allocator) void {
+            const self_ctx = @as(*@This(), @ptrCast(@alignCast(ctx)));
+            allocator.destroy(self_ctx);
+        }
+    };
+    
+    const context = try self.allocator.create(CreateEntityContext);
+    context.* = CreateEntityContext{
+        .entity_id = entity_id,
+        .components = components,
+    };
+    
+    const command = Command{
+        .context = context,
+        .execute = CreateEntityContext.execute,
+        .cleanup = CreateEntityContext.cleanup,
+    };
+    
+    try self.commands.append(self.allocator, command);
+    return entity_id;
 }
 
 pub fn removeEntity(self: *Transaction, entity_id: Entity.Id) !void {
-    // ...
+    // Create a context that captures the entity_id for deferred execution
+    const RemoveEntityContext = struct {
+        entity_id: Entity.Id,
+        
+        fn execute(ctx: *anyopaque, db: *Database) anyerror!void {
+            const self_ctx = @as(*@This(), @ptrCast(@alignCast(ctx)));
+            try db.removeEntity(self_ctx.entity_id);
+        }
+        
+        fn cleanup(ctx: *anyopaque, allocator: std.mem.Allocator) void {
+            const self_ctx = @as(*@This(), @ptrCast(@alignCast(ctx)));
+            allocator.destroy(self_ctx);
+        }
+    };
+    
+    const context = try self.allocator.create(RemoveEntityContext);
+    context.* = RemoveEntityContext{
+        .entity_id = entity_id,
+    };
+    
+    const command = Command{
+        .context = context,
+        .execute = RemoveEntityContext.execute,
+        .cleanup = RemoveEntityContext.cleanup,
+    };
+    
+    try self.commands.append(self.allocator, command);
 }
 
 pub fn addComponents(self: *Transaction, entity_id: Entity.Id, components: anytype) !void {
-    // ...
+    // Create a context that captures the entity_id and components for deferred execution
+    const AddComponentsContext = struct {
+        entity_id: Entity.Id,
+        components: @TypeOf(components),
+        
+        fn execute(ctx: *anyopaque, db: *Database) anyerror!void {
+            const self_ctx = @as(*@This(), @ptrCast(@alignCast(ctx)));
+            try db.addComponents(self_ctx.entity_id, self_ctx.components);
+        }
+        
+        fn cleanup(ctx: *anyopaque, allocator: std.mem.Allocator) void {
+            const self_ctx = @as(*@This(), @ptrCast(@alignCast(ctx)));
+            allocator.destroy(self_ctx);
+        }
+    };
+    
+    const context = try self.allocator.create(AddComponentsContext);
+    context.* = AddComponentsContext{
+        .entity_id = entity_id,
+        .components = components,
+    };
+    
+    const command = Command{
+        .context = context,
+        .execute = AddComponentsContext.execute,
+        .cleanup = AddComponentsContext.cleanup,
+    };
+    
+    try self.commands.append(self.allocator, command);
 }
 
 pub fn removeComponents(self: *Transaction, entity_id: Entity.Id, components: anytype) !void {
-    // ...
+    // Create a context that captures the entity_id and components for deferred execution
+    const RemoveComponentsContext = struct {
+        entity_id: Entity.Id,
+        components: @TypeOf(components),
+        
+        fn execute(ctx: *anyopaque, db: *Database) anyerror!void {
+            const self_ctx = @as(*@This(), @ptrCast(@alignCast(ctx)));
+            try db.removeComponents(self_ctx.entity_id, self_ctx.components);
+        }
+        
+        fn cleanup(ctx: *anyopaque, allocator: std.mem.Allocator) void {
+            const self_ctx = @as(*@This(), @ptrCast(@alignCast(ctx)));
+            allocator.destroy(self_ctx);
+        }
+    };
+    
+    const context = try self.allocator.create(RemoveComponentsContext);
+    context.* = RemoveComponentsContext{
+        .entity_id = entity_id,
+        .components = components,
+    };
+    
+    const command = Command{
+        .context = context,
+        .execute = RemoveComponentsContext.execute,
+        .cleanup = RemoveComponentsContext.cleanup,
+    };
+    
+    try self.commands.append(self.allocator, command);
 }

--- a/src/Transaction.zig
+++ b/src/Transaction.zig
@@ -13,7 +13,7 @@ has_executed: bool = false,
 const Transaction = @This();
 
 const Command = struct {
-    context: *anyopaque, // TODO: not sure this is the simplest way. the problem is that we need to capture the comptime components specs
+    context: *anyopaque,
     execute: *const fn (ctx: *anyopaque, db: *Database) anyerror!void,
     cleanup: *const fn (ctx: *anyopaque, allocator: std.mem.Allocator) void,
 };

--- a/src/Transaction.zig
+++ b/src/Transaction.zig
@@ -1,0 +1,49 @@
+const std = @import("std");
+const root = @import("root.zig");
+const Database = root.Database;
+const Entity = root.Entity;
+
+allocator: std.mem.Allocator,
+database: *Database,
+commands: std.ArrayListUnmanaged(Command) = .empty,
+
+const Transaction = @This();
+
+const Command = struct {
+    context: *anyopaque,
+    execute: *const fn (ctx: *anyopaque, db: *Database) anyerror!void,
+};
+
+pub fn init(allocator: std.mem.Allocator, database: *Database) Transaction {
+    return Transaction{
+        .allocator = allocator,
+        .database = database,
+    };
+}
+
+pub fn deinit(self: *Transaction) void {
+    self.commands.deinit(self.allocator);
+}
+
+pub fn execute(self: *Transaction) !void {
+    for (self.commands.items) |command| {
+        try command.execute(command.context, self.database);
+    }
+    self.commands.clear();
+}
+
+pub fn createEntity(self: *Transaction, components: anytype) !Entity.Id {
+    // ...
+}
+
+pub fn removeEntity(self: *Transaction, entity_id: Entity.Id) !void {
+    // ...
+}
+
+pub fn addComponents(self: *Transaction, entity_id: Entity.Id, components: anytype) !void {
+    // ...
+}
+
+pub fn removeComponents(self: *Transaction, entity_id: Entity.Id, components: anytype) !void {
+    // ...
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -2,14 +2,15 @@
 const std = @import("std");
 
 pub const Archetype = @import("Archetype.zig");
+pub const ComponentArray = @import("ComponentArray.zig");
+pub const ComponentMeta = @import("ComponentMeta.zig");
+pub const ComponentSet = @import("ComponentSet.zig");
 pub const Database = @import("Database.zig");
 pub const Entity = @import("Entity.zig");
-pub const Query = @import("Query.zig");
-pub const ComponentArray = @import("ComponentArray.zig");
-pub const ComponentSet = @import("ComponentSet.zig");
-pub const ComponentMeta = @import("ComponentMeta.zig");
-pub const Trait = @import("Trait.zig");
 pub const GroupBy = @import("GroupBy.zig");
+pub const Query = @import("Query.zig");
+pub const Trait = @import("Trait.zig");
+pub const Transaction = @import("Transaction.zig");
 
 /// `ComponentId` is a unique identifier for a component type. Use
 /// `componentId` to generate a `ComponentId` from a type.

--- a/src/tests/test_database.zig
+++ b/src/tests/test_database.zig
@@ -959,3 +959,224 @@ test "Database groupBy" {
     try testing.expect(group2_iterator.next().?.id == entity2a_id);
     try testing.expectEqual(null, group2_iterator.next());
 }
+
+test "Transaction - basic creation and execution" {
+    const allocator = std.testing.allocator;
+    var db = Database.init(allocator);
+    defer db.deinit();
+
+    var txn = db.transaction();
+    defer txn.deinit();
+
+    // Transaction should be empty initially
+    try testing.expectEqual(@as(usize, 0), txn.commands.items.len);
+
+    // Execute empty transaction (should not crash)
+    try txn.execute();
+}
+
+test "Transaction - deferred entity creation" {
+    const allocator = std.testing.allocator;
+    var db = Database.init(allocator);
+    defer db.deinit();
+
+    var txn = db.transaction();
+    defer txn.deinit();
+
+    // Create entity in transaction - should return valid ID but not create entity yet
+    const entity_id = try txn.createEntity(TestEntity.basic_positioned);
+    try testing.expectEqual(@as(usize, 1), txn.commands.items.len);
+    
+    // Entity should not exist in database yet
+    try testing.expect(db.getEntity(entity_id) == null);
+    try testing.expectEqual(@as(usize, 0), db.entities.count());
+
+    // Execute transaction
+    try txn.execute();
+
+    // Now entity should exist in database
+    const entity = db.getEntity(entity_id);
+    try testing.expect(entity != null);
+    try testing.expectEqual(@as(usize, 1), db.entities.count());
+    try testing.expectEqual(TestPositions.basic.x, entity.?.get(Position).?.x);
+    try testing.expectEqual(TestPositions.basic.y, entity.?.get(Position).?.y);
+
+    // Commands should be cleared after execution
+    try testing.expectEqual(@as(usize, 0), txn.commands.items.len);
+}
+
+test "Transaction - deferred entity removal" {
+    const allocator = std.testing.allocator;
+    var db = Database.init(allocator);
+    defer db.deinit();
+
+    // Create entity directly in database first
+    const entity_id = try db.createEntity(TestEntity.basic_positioned);
+    try testing.expect(db.getEntity(entity_id) != null);
+    try testing.expectEqual(@as(usize, 1), db.entities.count());
+
+    var txn = db.transaction();
+    defer txn.deinit();
+
+    // Queue entity removal in transaction
+    try txn.removeEntity(entity_id);
+    try testing.expectEqual(@as(usize, 1), txn.commands.items.len);
+
+    // Entity should still exist before execution
+    try testing.expect(db.getEntity(entity_id) != null);
+    try testing.expectEqual(@as(usize, 1), db.entities.count());
+
+    // Execute transaction
+    try txn.execute();
+
+    // Now entity should be removed
+    try testing.expect(db.getEntity(entity_id) == null);
+    try testing.expectEqual(@as(usize, 0), db.entities.count());
+}
+
+test "Transaction - deferred component addition" {
+    const allocator = std.testing.allocator;
+    var db = Database.init(allocator);
+    defer db.deinit();
+
+    // Create entity with just position
+    const entity_id = try db.createEntity(TestEntity.basic_positioned);
+    try testing.expect(db.getEntity(entity_id).?.get(Health) == null);
+
+    var txn = db.transaction();
+    defer txn.deinit();
+
+    // Queue adding health component
+    try txn.addComponents(entity_id, .{ TestHealth.full });
+    try testing.expectEqual(@as(usize, 1), txn.commands.items.len);
+
+    // Entity should not have health component yet
+    try testing.expect(db.getEntity(entity_id).?.get(Health) == null);
+
+    // Execute transaction
+    try txn.execute();
+
+    // Now entity should have health component
+    const entity = db.getEntity(entity_id).?;
+    const health = entity.get(Health).?;
+    try testing.expectEqual(TestHealth.full.current, health.current);
+    try testing.expectEqual(TestHealth.full.max, health.max);
+}
+
+test "Transaction - deferred component removal" {
+    const allocator = std.testing.allocator;
+    var db = Database.init(allocator);
+    defer db.deinit();
+
+    // Create entity with position and health
+    const entity_id = try db.createEntity(TestEntity.healthy_positioned);
+    try testing.expect(db.getEntity(entity_id).?.get(Health) != null);
+
+    var txn = db.transaction();
+    defer txn.deinit();
+
+    // Queue removing health component  
+    try txn.removeComponents(entity_id, .{ TestHealth.full });
+    try testing.expectEqual(@as(usize, 1), txn.commands.items.len);
+
+    // Entity should still have health component before execution
+    try testing.expect(db.getEntity(entity_id).?.get(Health) != null);
+
+    // Execute transaction
+    try txn.execute();
+
+    // Now entity should not have health component
+    const entity = db.getEntity(entity_id).?;
+    try testing.expect(entity.get(Health) == null);
+    try testing.expect(entity.get(Position) != null); // Position should remain
+}
+
+test "Transaction - multiple deferred commands" {
+    const allocator = std.testing.allocator;
+    var db = Database.init(allocator);
+    defer db.deinit();
+
+    var txn = db.transaction();
+    defer txn.deinit();
+
+    // Queue multiple operations
+    const entity1_id = try txn.createEntity(TestEntity.basic_positioned);
+    const entity2_id = try txn.createEntity(TestEntity.healthy_positioned);
+    try txn.addComponents(entity1_id, .{ TestHealth.damaged });
+    try txn.addComponents(entity2_id, .{ TestVelocity.moving_right });
+
+    try testing.expectEqual(@as(usize, 4), txn.commands.items.len);
+
+    // No entities should exist yet
+    try testing.expectEqual(@as(usize, 0), db.entities.count());
+
+    // Execute all commands
+    try txn.execute();
+
+    // All operations should be completed
+    try testing.expectEqual(@as(usize, 2), db.entities.count());
+
+    const entity1 = db.getEntity(entity1_id).?;
+    try testing.expect(entity1.get(Position) != null);
+    try testing.expect(entity1.get(Health) != null);
+    try testing.expectEqual(TestHealth.damaged.current, entity1.get(Health).?.current);
+
+    const entity2 = db.getEntity(entity2_id).?;
+    try testing.expect(entity2.get(Position) != null);
+    try testing.expect(entity2.get(Health) != null);
+    try testing.expect(entity2.get(Velocity) != null);
+    try testing.expectEqual(TestVelocity.moving_right.dx, entity2.get(Velocity).?.dx);
+}
+
+test "Transaction - immediate query operations" {
+    const allocator = std.testing.allocator;
+    var db = Database.init(allocator);
+    defer db.deinit();
+
+    // Create some entities directly in database
+    const existing_entity = try db.createEntity(TestEntity.basic_positioned);
+
+    var txn = db.transaction();
+    defer txn.deinit();
+
+    // Immediate operations should work (passthrough to db)
+    try testing.expect(txn.getEntity(existing_entity) != null);
+    
+    var query = try txn.query(.{Position});
+    defer query.deinit();
+    try testing.expectEqual(@as(usize, 1), query.count());
+
+    // Queue a deferred operation
+    _ = try txn.createEntity(TestEntity.healthy_positioned);
+
+    // Immediate query should still only see existing entities
+    var query2 = try txn.query(.{Position});
+    defer query2.deinit();
+    try testing.expectEqual(@as(usize, 1), query2.count());
+
+    // After execution, query should see both entities
+    try txn.execute();
+    
+    var query3 = try txn.query(.{Position});
+    defer query3.deinit();
+    try testing.expectEqual(@as(usize, 2), query3.count());
+}
+
+test "Transaction - double execute should fail" {
+    const allocator = std.testing.allocator;
+    var db = Database.init(allocator);
+    defer db.deinit();
+
+    var txn = db.transaction();
+    defer txn.deinit();
+
+    // Create an entity in the transaction
+    _ = try txn.createEntity(TestEntity.basic_positioned);
+
+    // Execute first time - should succeed
+    try txn.execute();
+
+    // Now try to execute again - should fail
+    const result = txn.execute();
+    try testing.expectError(error.TransactionAlreadyExecuted, result);
+}


### PR DESCRIPTION
This is a deferred command pattern similar to bevy's `Commands`. For now, this mostly prevents archetype changes mid-iteration. For example, calling `removeEntity` during a `Query` or `GroupBy` could easily result in invalidating the iterator(s).

In the future, this abstraction would also allow us to implement batching. One thing we could do is "bulk move" entities between archetypes.